### PR TITLE
Fix deprecation error on read() calls

### DIFF
--- a/src/Entities/AdAccounts.php
+++ b/src/Entities/AdAccounts.php
@@ -44,7 +44,7 @@ class AdAccounts
     public function get(array $fields, $accountId)
     {
         return $this->format(
-            (new AdAccount($accountId))->read($fields)
+            (new AdAccount($accountId))->getSelf($fields)
         );
     }
 }

--- a/src/Entities/InstagramAccounts.php
+++ b/src/Entities/InstagramAccounts.php
@@ -43,7 +43,7 @@ class InstagramAccounts
     public function get(array $fields, $accountId)
     {
         return $this->format(
-            (new FbAdAccount($accountId))->read($fields)
+            (new FbAdAccount($accountId))->getSelf($fields)
         );
     }
 }


### PR DESCRIPTION
php-business-sdk is throwing deprecation errors on read() calls in the latest release.

https://github.com/facebook/facebook-php-business-sdk/blob/3.3.3/src/FacebookAds/Object/AbstractCrudObject.php#L286